### PR TITLE
Fix Backquote

### DIFF
--- a/lib/page/keybind.js
+++ b/lib/page/keybind.js
@@ -227,7 +227,7 @@ const virtualKeyCodes = {
 	BracketRight: "]",
 	Semicolon: ";",
 	Quote: "'",
-	Backquote: '"',
+	Backquote: '`',
 	Backslash: "\\",
 	Comma: ",",
 	Period: "'.'",


### PR DESCRIPTION
I haven't tested this, and I'm not sure this is all that's necessary to fix it, but I'm coming from having reported https://github.com/th-ch/youtube-music/issues/499, where the prompt doesn't seem to handle this hotkey properly:

```
Ctrl + `
```

Seems like the `Backquote` key code (i.e. key code 192) wasn't mapped properly in the list, so it actually sets the hotkey to `Ctrl + "` instead (double quote) which is effectively `Ctrl + Shift + '` (because `Shift + '` -> `"`).