### PR TITLE
enable onwheel in number inputs

### DIFF
--- a/lib/page/prompt.js
+++ b/lib/page/prompt.js
@@ -214,6 +214,11 @@ function promptCreateInput(options) {
         }
     }
 
+    if (dataElement.getAttribute('type') === 'number') {
+        // somehow this is needed to activate wheel events on number inputs
+        dataElement.onwheel = () => {};
+    }
+
     //Cancel/Exit on 'Escape'
     dataElement.addEventListener('keyup', (event) => {
         if (event.key === 'Escape') {


### PR DESCRIPTION
This allows scrolling the mousewheel to change values inside an input of type `number`